### PR TITLE
feat: redesign --help with colors, hierarchy, and examples

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import chalk from "chalk";
 import { CleanOptions, CleanResult } from "./types.js";
+import { customHelpFormatter } from "./utils/helpFormatter.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf8")) as { version: string };
@@ -13,7 +14,8 @@ const program = new Command();
 program
   .name("mac-cleaner")
   .description("🧹 Clean dev caches on macOS — npm, Homebrew, Docker, Xcode, browsers, and more")
-  .version(pkg.version);
+  .version(pkg.version)
+  .configureHelp({ formatHelp: (cmd, helper) => customHelpFormatter(cmd, helper) });
 
 // ─── Helper to output results ──────────────────────────────────────────────
 
@@ -162,7 +164,7 @@ addCleanOptions(
 addCleanOptions(
   program
     .command("system")
-    .description("Shorthand for: clean system")
+    .description("Remove system logs, temp files & caches")
 ).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean }) => {
   const { clean } = await import("./cleaners/system.js");
   const result = await clean(opts as CleanOptions);
@@ -173,7 +175,7 @@ addCleanOptions(
 addCleanOptions(
   program
     .command("brew")
-    .description("Shorthand for: clean brew")
+    .description("Clear Homebrew cache & old package versions")
 ).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean }) => {
   const { clean } = await import("./cleaners/brew.js");
   const result = await clean(opts as CleanOptions);
@@ -184,7 +186,7 @@ addCleanOptions(
 addCleanOptions(
   program
     .command("node")
-    .description("Shorthand for: clean node")
+    .description("Wipe node_modules caches & npm/yarn/pnpm stores")
     .option("--include-orphans", "Also delete orphan node_modules (use carefully in monorepos)", false)
 ).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean; includeOrphans: boolean }) => {
   const { clean } = await import("./cleaners/node.js");
@@ -196,7 +198,7 @@ addCleanOptions(
 addCleanOptions(
   program
     .command("browser")
-    .description("Shorthand for: clean browser")
+    .description("Remove browser caches (Chrome, Safari, Firefox, Arc)")
 ).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean }) => {
   const { clean } = await import("./cleaners/browser.js");
   const result = await clean(opts as CleanOptions);
@@ -207,7 +209,7 @@ addCleanOptions(
 addCleanOptions(
   program
     .command("docker")
-    .description("Shorthand for: clean docker")
+    .description("Delete unused images, containers & volumes")
 ).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean }) => {
   const { clean } = await import("./cleaners/docker.js");
   const result = await clean(opts as CleanOptions);
@@ -218,7 +220,7 @@ addCleanOptions(
 addCleanOptions(
   program
     .command("xcode")
-    .description("Shorthand for: clean xcode")
+    .description("Clear Xcode derived data & simulator caches")
 ).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean }) => {
   const { clean } = await import("./cleaners/xcode.js");
   const result = await clean(opts as CleanOptions);
@@ -229,7 +231,7 @@ addCleanOptions(
 addCleanOptions(
   program
     .command("keychain")
-    .description("Shorthand for: clean keychain")
+    .description("Audit stale Keychain entries (read-only)")
 ).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean; secureDelete: boolean }) => {
   const { clean } = await import("./cleaners/keychain.js");
   const result = await clean(opts as CleanOptions);
@@ -240,7 +242,7 @@ addCleanOptions(
 addCleanOptions(
   program
     .command("privacy")
-    .description("Shorthand for: clean privacy")
+    .description("Clear app usage history & recent files")
 ).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean; secureDelete: boolean }) => {
   const { clean } = await import("./cleaners/privacy.js");
   const result = await clean(opts as CleanOptions);
@@ -251,7 +253,7 @@ addCleanOptions(
 addCleanOptions(
   program
     .command("all")
-    .description("Shorthand for: clean all")
+    .description("Clean everything at once (safe defaults)")
 ).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean; secureDelete: boolean }) => {
   const { clean } = await import("./cleaners/all.js");
   const result = await clean(opts as CleanOptions);

--- a/src/utils/helpFormatter.ts
+++ b/src/utils/helpFormatter.ts
@@ -1,0 +1,114 @@
+import chalk from "chalk";
+import { Command, Help } from "commander";
+
+const DIVIDER = chalk.gray("─".repeat(61));
+
+const COMMANDS = {
+  CLEAN: [
+    { name: "all",      desc: "Clean everything at once (safe defaults)" },
+    { name: "system",   desc: "Remove system logs, temp files & caches" },
+    { name: "brew",     desc: "Clear Homebrew cache & old package versions" },
+    { name: "node",     desc: "Wipe node_modules caches & npm/yarn/pnpm stores" },
+    { name: "browser",  desc: "Remove browser caches (Chrome, Safari, Firefox, Arc)" },
+    { name: "docker",   desc: "Delete unused images, containers & volumes" },
+    { name: "xcode",    desc: "Clear Xcode derived data & simulator caches" },
+    { name: "keychain", desc: "Audit stale Keychain entries (read-only)" },
+    { name: "privacy",  desc: "Clear app usage history & recent files" },
+    { name: "scan",     desc: "Scan caches for accidentally exposed secrets" },
+  ],
+  MAINTENANCE: [
+    { name: "upgrade",  desc: "Update mac-cleaner to the latest version" },
+  ],
+  OTHER: [
+    { name: "help [command]", desc: "Show help for a specific command" },
+  ],
+};
+
+const COMMON_FLAGS = [
+  { flag: "--dry-run",         desc: "Preview what would be deleted (no changes made)" },
+  { flag: "--verbose, -v",     desc: "Show detailed output per file/folder" },
+  { flag: "--json",            desc: "Output results as JSON (useful for scripts)" },
+  { flag: "--no-sudo",         desc: "Skip privileged paths without prompting" },
+  { flag: "-y, --yes",         desc: "Non-interactive / CI mode" },
+  { flag: "--secure-delete",   desc: "Overwrite files before deletion (slower, safer)" },
+  { flag: "--include-orphans", desc: "Also remove orphan node_modules (use carefully)" },
+];
+
+const EXAMPLES = [
+  { cmd: "mac-cleaner all --dry-run",       comment: "# Preview full cleanup" },
+  { cmd: "mac-cleaner node --verbose",      comment: "# Clean node with details" },
+  { cmd: "mac-cleaner brew",                comment: "# Quick Homebrew cleanup" },
+  { cmd: "mac-cleaner all --json | jq .",   comment: "# JSON output for scripting" },
+  { cmd: "mac-cleaner scan",                comment: "# Check for leaked secrets" },
+  { cmd: "mac-cleaner upgrade",             comment: "# Update to latest version" },
+];
+
+function col(name: string, width: number): string {
+  return name.padEnd(width);
+}
+
+function renderCommandGroup(label: string, commands: Array<{ name: string; desc: string }>): string {
+  const lines: string[] = [];
+  lines.push(chalk.bold.white(label));
+  lines.push(DIVIDER);
+  for (const { name, desc } of commands) {
+    lines.push(`  ${chalk.bold.cyan(col(name, 20))}${chalk.white(desc)}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function customHelpFormatter(cmd: Command, _helper: Help): string {
+  // Detect version from the program's version string
+  const version = cmd.version() || "";
+
+  const lines: string[] = [];
+
+  // ── Header ────────────────────────────────────────────────────────────────
+  lines.push("");
+  lines.push(`${chalk.bold.cyan("🧹 mac-cleaner")} ${chalk.gray(version ? `v${version}` : "")}`);
+  lines.push("");
+  lines.push(chalk.italic.white("Clean dev caches on macOS — npm, Homebrew, Docker, Xcode, browsers, and more"));
+  lines.push("");
+
+  // ── Usage ─────────────────────────────────────────────────────────────────
+  lines.push(chalk.bold.yellow("USAGE"));
+  lines.push("");
+  lines.push(`  mac-cleaner ${chalk.bold.cyan("<command>")} ${chalk.gray("[options]")}`);
+  lines.push("");
+
+  // ── Commands ──────────────────────────────────────────────────────────────
+  lines.push(chalk.bold.yellow("COMMANDS"));
+  lines.push("");
+  lines.push(renderCommandGroup("CLEAN", COMMANDS.CLEAN));
+  lines.push(renderCommandGroup("MAINTENANCE", COMMANDS.MAINTENANCE));
+  lines.push(renderCommandGroup("OTHER", COMMANDS.OTHER));
+
+  // ── Options ───────────────────────────────────────────────────────────────
+  lines.push(chalk.bold.yellow("OPTIONS"));
+  lines.push("");
+  lines.push(`  ${chalk.bold.green(col("-V, --version", 28))}${chalk.gray("Print version number")}`);
+  lines.push(`  ${chalk.bold.green(col("-h, --help", 28))}${chalk.gray("Show this help message")}`);
+  lines.push("");
+
+  lines.push(chalk.bold.yellow("COMMON FLAGS") + chalk.gray("  (all clean commands)"));
+  lines.push("");
+  for (const { flag, desc } of COMMON_FLAGS) {
+    lines.push(`  ${chalk.bold.green(col(flag, 28))}${chalk.gray(desc)}`);
+  }
+  lines.push("");
+
+  // ── Examples ──────────────────────────────────────────────────────────────
+  lines.push(chalk.bold.yellow("EXAMPLES"));
+  lines.push("");
+  for (const { cmd: c, comment } of EXAMPLES) {
+    lines.push(`  ${chalk.gray("$")} ${chalk.bold.white(c)}  ${chalk.gray(comment)}`);
+  }
+  lines.push("");
+
+  // ── Docs ──────────────────────────────────────────────────────────────────
+  lines.push(`  ${chalk.underline.blue("https://github.com/BlackAsteroid/mac-cleaner-cli")}`);
+  lines.push("");
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
Closes #56
Closes #57

## Issue #57 — Register upgrade + improve all descriptions

- `upgrade` now appears in the help under MAINTENANCE group
- All "Shorthand for: clean X" descriptions replaced with human-readable copy (per Pato's spec)

## Issue #56 — Help redesign

New `src/utils/helpFormatter.ts` with `customHelpFormatter()`, registered via:
```ts
program.configureHelp({ formatHelp: (cmd, helper) => customHelpFormatter(cmd, helper) })
```

**Layout (Pato's spec):**
```
🧹 mac-cleaner v1.4.0

Clean dev caches on macOS — npm, Homebrew, Docker, Xcode, browsers, and more

USAGE

  mac-cleaner <command> [options]

COMMANDS

CLEAN
─────────────────────────────────────────────────────────────
  all                   Clean everything at once (safe defaults)
  system                Remove system logs, temp files & caches
  ...

MAINTENANCE
─────────────────────────────────────────────────────────────
  upgrade               Update mac-cleaner to the latest version

COMMON FLAGS  (all clean commands)

  --dry-run             Preview what would be deleted (no changes made)
  --verbose, -v         Show detailed output per file/folder
  ...

EXAMPLES

  $ mac-cleaner all --dry-run    # Preview full cleanup
  $ mac-cleaner node --verbose   # Clean node with details
  $ mac-cleaner upgrade          # Update to latest version

  https://github.com/BlackAsteroid/mac-cleaner-cli
```

**Color map:** section headers → bold.yellow, commands → bold.cyan, flags → bold.green, dividers → gray, examples → bold.white with gray comments, URL → underline.blue