### PR TITLE
fix: add timeouts to all spawnSync which/test calls (brew hang fix)

### DIFF
--- a/src/cleaners/brew.ts
+++ b/src/cleaners/brew.ts
@@ -8,11 +8,11 @@ import { renderSummaryTable } from "../utils/format.js";
 function findBrewPath(): string | null {
   const candidates = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"];
   for (const p of candidates) {
-    const result = spawnSync("test", ["-x", p], { shell: false });
+    const result = spawnSync("test", ["-x", p], { shell: false, timeout: 3000 });
     if (result.status === 0) return p;
   }
-  // Try which
-  const which = spawnSync("which", ["brew"], { encoding: "utf8" });
+  // Try which — with timeout to prevent hanging on broken PATH
+  const which = spawnSync("which", ["brew"], { encoding: "utf8", timeout: 5000 });
   if (which.status === 0 && which.stdout.trim()) return which.stdout.trim();
   return null;
 }
@@ -33,13 +33,13 @@ export async function clean(options: CleanOptions): Promise<CleanResult> {
   if (spinner) spinner.text = "Getting Homebrew cache size...";
 
   // Get cache path
-  const cacheResult = spawnSync(brewPath, ["--cache"], { encoding: "utf8" });
+  const cacheResult = spawnSync(brewPath, ["--cache"], { encoding: "utf8", timeout: 5000 });
   const cachePath = cacheResult.stdout.trim();
 
   // Get size before cleanup
   let sizeBefore = 0;
   if (cachePath) {
-    const duResult = spawnSync("du", ["-sk", cachePath], { encoding: "utf8" });
+    const duResult = spawnSync("du", ["-sk", cachePath], { encoding: "utf8", timeout: 10000 });
     if (duResult.stdout) {
       const kb = parseInt(duResult.stdout.split("\t")[0], 10);
       if (!isNaN(kb)) sizeBefore = kb * 1024;

--- a/src/cleaners/docker.ts
+++ b/src/cleaners/docker.ts
@@ -6,7 +6,7 @@ import { formatBytes } from "../utils/du.js";
 import { renderSummaryTable } from "../utils/format.js";
 
 function findDockerPath(): string | null {
-  const which = spawnSync("which", ["docker"], { encoding: "utf8" });
+  const which = spawnSync("which", ["docker"], { encoding: "utf8", timeout: 5000 });
   if (which.status === 0 && which.stdout.trim()) return which.stdout.trim();
   return null;
 }

--- a/src/cleaners/node.ts
+++ b/src/cleaners/node.ts
@@ -90,7 +90,7 @@ function cleanWithTool(
   args: string[],
   errors: string[]
 ): boolean {
-  const which = spawnSync("which", [tool], { encoding: "utf8" });
+  const which = spawnSync("which", [tool], { encoding: "utf8", timeout: 5000 });
   if (which.status !== 0 || !which.stdout.trim()) {
     errors.push(`${tool} not found — skipping`);
     return false;

--- a/src/cleaners/xcode.ts
+++ b/src/cleaners/xcode.ts
@@ -25,7 +25,7 @@ function isXcodeInstalled(): boolean {
 }
 
 function cleanSimulators(errors: string[], dryRun: boolean): number {
-  const xcrunPath = spawnSync("which", ["xcrun"], { encoding: "utf8" });
+  const xcrunPath = spawnSync("which", ["xcrun"], { encoding: "utf8", timeout: 5000 });
   if (xcrunPath.status !== 0) {
     errors.push("xcrun not found — cannot clean simulators");
     return 0;


### PR DESCRIPTION
Closes #60

## Root cause
`findBrewPath()` in `brew.ts` called `spawnSync("test", ["-x", path])` and `spawnSync("which", ["brew"])` without any timeout. On systems with broken PATH resolution, a misconfigured shell, or slow startup scripts, `which` can block indefinitely — freezing `mac-cleaner brew` with the spinner stuck on "Looking for Homebrew...".

## Fix
Added explicit timeouts to ALL `which` / `test` discovery calls across all cleaners:
- `brew.ts`: `test -x` → 3000ms, `which brew` → 5000ms, `brew --cache` → 5000ms, `du` → 10000ms
- `docker.ts`: `which docker` → 5000ms
- `node.ts`: `which <tool>` → 5000ms
- `xcode.ts`: `which xcrun` → 5000ms

After timeout, `spawnSync` returns `status: null` — treated as not installed, skips gracefully with a warning.