### PR TITLE
fix: spinner/prompt conflict + live path progress in cleaners

### DIFF
--- a/src/cleaners/browser.ts
+++ b/src/cleaners/browser.ts
@@ -6,7 +6,7 @@ import chalk from "chalk";
 import { createSpinner } from "../utils/spinner.js";
 import { CleanOptions, CleanResult } from "../types.js";
 import { duBytes, formatBytes } from "../utils/du.js";
-import { renderSummaryTable, verboseLine } from "../utils/format.js";
+import { renderSummaryTable, verboseLine, truncatePath } from "../utils/format.js";
 import { writeAuditLog } from "../utils/auditLog.js";
 
 const home = os.homedir();
@@ -78,6 +78,7 @@ export async function clean(options: CleanOptions): Promise<CleanResult> {
   if (spinner) spinner.text = `Cleaning ${allCandidates.length} browser cache paths...`;
 
   for (const { browser, path: p } of allCandidates) {
+    if (spinner) spinner.text = `[${browser}] Cleaning: ${truncatePath(p)}`;
     const size = duBytes(p);
     try {
       // #41: Secure delete — overwrite file with zeros before removal (macOS, files only)

--- a/src/cleaners/node.ts
+++ b/src/cleaners/node.ts
@@ -6,7 +6,7 @@ import chalk from "chalk";
 import { createSpinner } from "../utils/spinner.js";
 import { CleanOptions, CleanResult } from "../types.js";
 import { duBytes, formatBytes } from "../utils/du.js";
-import { renderSummaryTable, verboseLine } from "../utils/format.js";
+import { renderSummaryTable, verboseLine, truncatePath } from "../utils/format.js";
 import { isSafeToDelete } from "../utils/safeDelete.js";
 import { promptSudoPassword, verifySudoPassword } from "../utils/sudo.js";
 
@@ -241,6 +241,7 @@ export async function clean(options: NodeCleanOptions): Promise<CleanResult> {
     if (options.includeOrphans) {
       if (spinner) spinner.text = `Removing ${orphans.length} orphan node_modules...`;
       for (const orphan of orphans) {
+        if (spinner) spinner.text = `Removing orphan: ${truncatePath(orphan)}`;
         // Security (#43): resolve symlinks before deletion to prevent traversal attacks
         if (!isSafeToDelete(orphan, os.homedir())) {
           errors.push(`Skipped (symlink escape detected): ${orphan}`);

--- a/src/cleaners/system.ts
+++ b/src/cleaners/system.ts
@@ -6,7 +6,7 @@ import chalk from "chalk";
 import { createSpinner } from "../utils/spinner.js";
 import { CleanOptions, CleanResult } from "../types.js";
 import { duBytes, formatBytes } from "../utils/du.js";
-import { renderSummaryTable, SummaryRow, verboseLine } from "../utils/format.js";
+import { renderSummaryTable, SummaryRow, verboseLine, truncatePath } from "../utils/format.js";
 import { isPrivilegedPath } from "../utils/privilegedPaths.js";
 import { promptSudoPassword, sudoRmRf, verifySudoPassword } from "../utils/sudo.js";
 import { isSafeToDelete } from "../utils/safeDelete.js";
@@ -151,6 +151,7 @@ export async function clean(options: CleanOptions): Promise<CleanResult> {
   let permissionSkipped = 0;
 
   for (const p of normalPaths) {
+    if (spinner) spinner.text = `Cleaning: ${truncatePath(p)}`;
     const prevErrorCount = errors.length;
     const size = removePathSafe(p, errors, os.homedir(), options);
     if (size > 0 || !fs.existsSync(p)) {

--- a/src/cleaners/xcode.ts
+++ b/src/cleaners/xcode.ts
@@ -6,7 +6,7 @@ import chalk from "chalk";
 import { createSpinner } from "../utils/spinner.js";
 import { CleanOptions, CleanResult } from "../types.js";
 import { duBytes, formatBytes } from "../utils/du.js";
-import { renderSummaryTable, verboseLine } from "../utils/format.js";
+import { renderSummaryTable, verboseLine, truncatePath } from "../utils/format.js";
 
 const home = os.homedir();
 
@@ -101,7 +101,7 @@ export async function clean(options: CleanOptions): Promise<CleanResult> {
   // Clean DerivedData and caches
   for (const p of targetPaths) {
     if (fs.existsSync(p)) {
-      if (spinner) spinner.text = `Cleaning ${path.basename(p)}...`;
+      if (spinner) spinner.text = `Cleaning: ${truncatePath(p)}`;
       const size = duBytes(p);
       try {
         fs.rmSync(p, { recursive: true, force: true });

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -83,6 +83,20 @@ function statusStr(icon: string, width: number): string {
 }
 
 /**
+ * Truncates a filesystem path to fit within a terminal column limit.
+ * Truncates from the left so the meaningful end of the path is always visible.
+ *
+ * Example: /Users/pablo/Library/Caches/Google/Chrome → …ry/Caches/Google/Chrome
+ */
+export function truncatePath(filePath: string, maxLen?: number): string {
+  const cols = maxLen ?? (process.stdout.columns || 80);
+  // Reserve space for spinner prefix (≈ 12 chars: "  ⟳ Cleaning: ")
+  const available = Math.max(20, cols - 14);
+  if (filePath.length <= available) return filePath;
+  return `…${filePath.slice(-(available - 1))}`;
+}
+
+/**
  * Prints a single verbose path line (only shown when --verbose is active).
  */
 export function verboseLine(label: string, targetPath: string, size: number, dryRun: boolean): void {


### PR DESCRIPTION
Closes #68
Closes #71

## Fix #68 — Stop spinner before npm sudo prompt (node.ts)

When `mac-cleaner node` detects EACCES and offers the auto-fix, the ora spinner was still animating in stdout while the password prompt was written to stderr. Same conflict as Issue #48.

Fix: `spinner.stop()` before `promptSudoPassword()`, `spinner.start()` after the sudo interaction.

## Feat #71 — Live path progress in spinner

### src/utils/format.ts — `truncatePath(path, maxLen?)`
Truncates from the LEFT so the meaningful end of the path is always visible. Respects `process.stdout.columns` (default 80).

```
/Users/pablo/Library/Caches/Google/Chrome/Default/Cache
→ …y/Caches/Google/Chrome/Default/Cache
```

### Cleaners updated
- **system.ts**: `Cleaning: <truncated path>`
- **browser.ts**: `[Chrome] Cleaning: <truncated path>`
- **xcode.ts**: `Cleaning: <truncated path>`
- **node.ts**: `Removing orphan: <truncated path>`