### PR TITLE
docs: add demo video link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A fast, safe CLI for cleaning macOS development caches. Reclaim gigabytes of dis
 
 ![mac-cleaner hero](.github/assets/hero.png)
 
+[**▶ Watch demo (75s)**](https://github.com/BlackAsteroid/mac-cleaner-cli/releases/download/v1.5.5/demo.mp4)
+
 [![npm version](https://img.shields.io/npm/v/@blackasteroid/mac-cleaner-cli?color=cyan&label=npm)](https://www.npmjs.com/package/@blackasteroid/mac-cleaner-cli)
 [![Build](https://github.com/BlackAsteroid/mac-cleaner-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/BlackAsteroid/mac-cleaner-cli/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)


### PR DESCRIPTION
Closes #80

Adds the Remotion demo video produced by Pato to the README.

**Video:** https://github.com/BlackAsteroid/mac-cleaner-cli/releases/download/v1.5.5/demo.mp4
- 75 seconds · 1920×1080 · h264 · 4.2 MB
- 5 scenes: hook, dry-run preview, real run, orphan finder, outro

The video link appears below the hero image as a text link — no extra image duplication, renders cleanly on GitHub.