### PR TITLE
fix(ci): increase all.test.ts timeouts for CI

### DIFF
--- a/src/cleaners/all.test.ts
+++ b/src/cleaners/all.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { clean } from "./all.js";
 
+// clean all runs every module sequentially including docker/keychain which each
+// have spawnSync('which') calls with 5s timeouts in CI. Use generous timeouts.
 describe("clean all", () => {
   it("returns ok:true in dry-run across all modules", async () => {
     const result = await clean({ dryRun: true, json: true });
     expect(result.ok).toBe(true);
-  });
+  }, 60000);
 
   it("--json mode returns parseable CleanResult structure", async () => {
     const result = await clean({ dryRun: true, json: true });
@@ -19,11 +21,11 @@ describe("clean all", () => {
     expect(typeof result.freed).toBe("number");
     expect(Array.isArray(result.errors)).toBe(true);
     expect(() => JSON.stringify(result)).not.toThrow();
-  });
+  }, 60000);
 
   it("aggregates results from multiple modules (paths is array, freed >= 0)", async () => {
     const result = await clean({ dryRun: true, json: true });
     expect(result.freed).toBeGreaterThanOrEqual(0);
     expect(result.paths.length).toBeGreaterThanOrEqual(0);
-  });
+  }, 60000);
 });


### PR DESCRIPTION
Prevents CI failures from all.test.ts timing out.\n\nclean all runs 7+ modules sequentially with spawnSync calls that each have 5s timeouts. The default 5s vitest timeout is insufficient — bumped to 60s per test.