### PR TITLE
fix: polish CLI output — double tick, table alignment, permission noise

### DIFF
--- a/src/cleaners/all.ts
+++ b/src/cleaners/all.ts
@@ -39,17 +39,11 @@ export async function clean(options: CleanOptions): Promise<CleanResult> {
   const allErrors: string[] = [];
 
   for (const { label, cleaner } of modules) {
-    if (!options.json) {
-      process.stdout.write(chalk.gray(`  Running ${label} cleaner...`));
-    }
     const result = await cleaner.clean(subOptions);
     results.push({ name: label, result });
     totalFreed += result.freed;
     allPaths.push(...result.paths);
     allErrors.push(...result.errors);
-    if (!options.json) {
-      process.stdout.write(chalk.green(" ✔\n"));
-    }
   }
 
   // #26: JSON per-module breakdown

--- a/src/cleaners/browser.ts
+++ b/src/cleaners/browser.ts
@@ -102,7 +102,12 @@ export async function clean(options: CleanOptions): Promise<CleanResult> {
         verboseLine(browser, p, size, false);
       }
     } catch (err) {
-      errors.push(`Failed to remove ${p}: ${(err as Error).message}`);
+      const msg = (err as Error).message;
+      if (msg.includes("EPERM") || msg.includes("EACCES")) {
+        errors.push(`Skipped (protected by macOS): ${p}`);
+      } else {
+        errors.push(`Failed to remove ${p}: ${msg}`);
+      }
     }
   }
 

--- a/src/cleaners/privacy.ts
+++ b/src/cleaners/privacy.ts
@@ -117,7 +117,9 @@ export async function clean(options: CleanOptions): Promise<CleanResult> {
     if (options.verbose && !options.json) {
       console.log(chalk.gray(`    [privacy] cleared com.apple.finder RecentFolders`));
     }
-  } else if (finderResult.stderr && !finderResult.stderr.includes("does not exist")) {
+  } else if (finderResult.stderr &&
+             !finderResult.stderr.includes("does not exist") &&
+             !finderResult.stderr.includes("not found")) {
     errors.push(`defaults delete com.apple.finder RecentFolders: ${finderResult.stderr.trim()}`);
   }
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -50,8 +50,8 @@ export function renderSummaryTable(rows: SummaryRow[], dryRun = false): void {
 
     console.log(
       row.module.padEnd(COL_MODULE) +
-      pathsStr.padStart(COL_PATHS) +
-      freedStr.padStart(COL_FREED) +
+      ansiPadStart(pathsStr, COL_PATHS) +
+      ansiPadStart(freedStr, COL_FREED) +
       statusStr(statusIcon, COL_STATUS)
     );
   }
@@ -62,7 +62,7 @@ export function renderSummaryTable(rows: SummaryRow[], dryRun = false): void {
     console.log(
       chalk.bold("Total".padEnd(COL_MODULE)) +
       chalk.bold(String(totalPaths).padStart(COL_PATHS)) +
-      chalk.bold(totalFreedStr.padStart(COL_FREED)) +
+      chalk.bold(ansiPadStart(totalFreedStr, COL_FREED)) +
       " ".padStart(COL_STATUS)
     );
   }
@@ -75,11 +75,15 @@ export function renderSummaryTable(rows: SummaryRow[], dryRun = false): void {
   console.log();
 }
 
-function statusStr(icon: string, width: number): string {
-  // chalk adds invisible ANSI chars — pad the visible content only
-  const visible = icon.replace(/\x1b\[[0-9;]*m/g, "");
+/** Pad a string that may contain ANSI escape codes to a given visible width (right-aligned). */
+function ansiPadStart(str: string, width: number): string {
+  const visible = str.replace(/\x1b\[[0-9;]*m/g, "");
   const padding = Math.max(0, width - visible.length);
-  return " ".repeat(padding) + icon;
+  return " ".repeat(padding) + str;
+}
+
+function statusStr(icon: string, width: number): string {
+  return ansiPadStart(icon, width);
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Double tick removed**: The `all` orchestrator was printing its own `✔` after each cleaner, but each cleaner already outputs `✔ System cleaned` etc. via its spinner — resulting in a stray checkmark on a blank line after every module
- **Table alignment fixed**: Summary table columns broke when `chalk.gray("0")` or `chalk.gray("—")` was used for zero/empty values — `.padStart()` counted invisible ANSI escape characters. Added `ansiPadStart()` that strips ANSI before measuring
- **Permission noise cleaned up**: Browser EPERM errors now show `Skipped (protected by macOS)` instead of raw Node.js error messages. Privacy `defaults delete` stderr filter now also catches `"not found"` (macOS says "Domain … not found", not "does not exist")

## Test plan
- [ ] Run `mac-cleaner all` — verify single checkmark per module, no blank `✔` lines
- [ ] Check summary table alignment with modules that clean 0 paths
- [ ] Run on machine with SIP-protected Safari caches — verify friendly skip message
- [ ] Run `mac-cleaner all --json` — verify JSON output unchanged
- [ ] Run `mac-cleaner all --dry-run` — verify dry-run still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)