### PR TITLE
docs: highlight Homebrew as recommended install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A fast, safe CLI for cleaning macOS development caches. Reclaim gigabytes of dis
 
 
 [![npm version](https://img.shields.io/npm/v/@blackasteroid/mac-cleaner-cli?color=cyan&label=npm)](https://www.npmjs.com/package/@blackasteroid/mac-cleaner-cli)
+[![homebrew](https://img.shields.io/badge/homebrew-tap-orange)](https://github.com/BlackAsteroid/homebrew-tap)
 [![Build](https://github.com/BlackAsteroid/mac-cleaner-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/BlackAsteroid/mac-cleaner-cli/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
@@ -25,6 +26,16 @@ mac-cleaner all
 ---
 
 ## Install
+
+### Homebrew (recommended)
+
+```bash
+brew install BlackAsteroid/tap/mac-cleaner
+```
+
+This taps the [BlackAsteroid/tap](https://github.com/BlackAsteroid/homebrew-tap) and installs `mac-cleaner` with all dependencies managed automatically.
+
+### npm
 
 ```bash
 npm install -g @blackasteroid/mac-cleaner-cli


### PR DESCRIPTION
## Summary
- Add Homebrew badge to the shields row
- Rewrite Install section with **Homebrew as the recommended method** (`brew install BlackAsteroid/tap/mac-cleaner`) and npm as a secondary option
- Formula was added to [BlackAsteroid/homebrew-tap](https://github.com/BlackAsteroid/homebrew-tap) in a separate commit

## Test plan
- [ ] Verify `brew install BlackAsteroid/tap/mac-cleaner` works end-to-end
- [ ] Confirm badge renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)