### PR TITLE
feat: expanded maintenance scripts

### DIFF
--- a/src/cleaners/maintain.test.ts
+++ b/src/cleaners/maintain.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { clean } from "./maintain.js";
+
+describe("maintain cleaner", () => {
+  it("dry-run returns ok:true", async () => {
+    const result = await clean({ dryRun: true, json: true });
+    expect(result.ok).toBe(true);
+  });
+
+  it("--json mode returns parseable CleanResult structure", async () => {
+    const result = await clean({ dryRun: true, json: true });
+
+    expect(result).toHaveProperty("ok");
+    expect(result).toHaveProperty("paths");
+    expect(result).toHaveProperty("freed");
+    expect(result).toHaveProperty("errors");
+    expect(typeof result.ok).toBe("boolean");
+    expect(Array.isArray(result.paths)).toBe(true);
+    expect(typeof result.freed).toBe("number");
+    expect(Array.isArray(result.errors)).toBe(true);
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it("dry-run freed is always 0 (maintenance frees no disk space)", async () => {
+    const result = await clean({ dryRun: true, json: true });
+    expect(result.freed).toBe(0);
+  });
+
+  it("paths contain task labels, not file paths", async () => {
+    const result = await clean({ dryRun: true, json: true });
+    // Maintenance tasks return labels like "Flush DNS cache", not file paths
+    for (const p of result.paths) {
+      expect(p).not.toMatch(/^\//);
+    }
+  });
+
+  it("skips sudo tasks when noSudo is set", async () => {
+    const result = await clean({ dryRun: true, json: true, noSudo: true });
+
+    // Should not include sudo-only tasks
+    const sudoTasks = ["Restart mDNSResponder", "Rebuild Spotlight index", "Purge inactive memory", "Clear font caches"];
+    for (const task of sudoTasks) {
+      expect(result.paths).not.toContain(task);
+    }
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/cleaners/maintain.ts
+++ b/src/cleaners/maintain.ts
@@ -1,0 +1,192 @@
+import { spawnSync } from "child_process";
+import chalk from "chalk";
+import { createSpinner } from "../utils/spinner.js";
+import { CleanOptions, CleanResult } from "../types.js";
+import { renderSummaryTable, SummaryRow } from "../utils/format.js";
+import { writeAuditLog } from "../utils/auditLog.js";
+
+interface MaintenanceTask {
+  label: string;
+  description: string;
+  command: string;
+  args: string[];
+  requiresSudo: boolean;
+}
+
+const LSREGISTER_PATH =
+  "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister";
+
+const tasks: MaintenanceTask[] = [
+  {
+    label: "Flush DNS cache",
+    description: "Clear the local DNS resolver cache",
+    command: "dscacheutil",
+    args: ["-flushcache"],
+    requiresSudo: false,
+  },
+  {
+    label: "Restart mDNSResponder",
+    description: "Send HUP signal to mDNSResponder to complete DNS flush",
+    command: "sudo",
+    args: ["-n", "killall", "-HUP", "mDNSResponder"],
+    requiresSudo: true,
+  },
+  {
+    label: "Rebuild Spotlight index",
+    description: "Erase and rebuild the Spotlight metadata index",
+    command: "sudo",
+    args: ["-n", "mdutil", "-E", "/"],
+    requiresSudo: true,
+  },
+  {
+    label: "Repair disk permissions",
+    description: "Reset user permissions on the boot volume",
+    command: "diskutil",
+    args: ["resetUserPermissions", "/", String(process.getuid?.() ?? 501)],
+    requiresSudo: false,
+  },
+  {
+    label: "Rebuild Launch Services database",
+    description: "Clear and rebuild the Launch Services registration database",
+    command: LSREGISTER_PATH,
+    args: ["-kill", "-r", "-domain", "local", "-domain", "system", "-domain", "user"],
+    requiresSudo: false,
+  },
+  {
+    label: "Purge inactive memory",
+    description: "Force macOS to purge inactive memory from RAM",
+    command: "sudo",
+    args: ["-n", "purge"],
+    requiresSudo: true,
+  },
+  {
+    label: "Clear font caches",
+    description: "Remove cached font data so the system rebuilds it on next use",
+    command: "sudo",
+    args: ["-n", "atsutil", "databases", "-remove"],
+    requiresSudo: true,
+  },
+];
+
+export async function clean(options: CleanOptions): Promise<CleanResult> {
+  const suppressTable = (options as any)._suppressTable === true;
+  const spinner = options.json ? null : createSpinner("Running maintenance tasks...").start();
+  const errors: string[] = [];
+  const completedTasks: string[] = [];
+  const skipSudo = options.noSudo || options.yes;
+
+  // ── Dry run ──────────────────────────────────────────────────────────────
+  if (options.dryRun) {
+    if (spinner) spinner.succeed(chalk.yellow("Dry run -- nothing executed"));
+
+    for (const task of tasks) {
+      if (task.requiresSudo && skipSudo) {
+        if (options.verbose && !options.json) {
+          console.log(chalk.gray(`  [dry-run] skip (no-sudo): ${task.label} -- ${task.description}`));
+        }
+        continue;
+      }
+      completedTasks.push(task.label);
+      if (options.verbose && !options.json) {
+        console.log(chalk.gray(`  [dry-run] would run: ${task.label} -- ${task.description}`));
+      }
+    }
+
+    if (!options.json && !suppressTable) {
+      const skipped = tasks.filter((t) => t.requiresSudo && skipSudo).length;
+      const rows: SummaryRow[] = [
+        {
+          module: "Maintain",
+          paths: completedTasks.length,
+          freed: 0,
+          status: "would_free",
+          warnings: skipped,
+        },
+      ];
+      renderSummaryTable(rows, true);
+    }
+
+    return { ok: true, paths: completedTasks, freed: 0, errors };
+  }
+
+  // ── Real run ─────────────────────────────────────────────────────────────
+  let succeeded = 0;
+  let failed = 0;
+  let skipped = 0;
+
+  for (const task of tasks) {
+    if (task.requiresSudo && skipSudo) {
+      skipped++;
+      if (options.verbose && !options.json) {
+        console.log(chalk.gray(`  [skipped] ${task.label} (requires sudo)`));
+      }
+      continue;
+    }
+
+    if (spinner) spinner.text = task.label;
+
+    const result = spawnSync(task.command, task.args, {
+      encoding: "utf8",
+      timeout: 30_000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    if (result.status === 0) {
+      succeeded++;
+      completedTasks.push(task.label);
+      if (options.verbose && !options.json) {
+        console.log(chalk.gray(`  [done] ${task.label}`));
+      }
+    } else {
+      failed++;
+      const stderr = (result.stderr ?? "").trim();
+      // Filter out sudo password prompts from error messages
+      const safeStderr = stderr.replace(/password[:\s]*/gi, "[password prompt]").trim();
+      const msg = safeStderr || `exit code ${result.status}`;
+      errors.push(`${task.label}: ${msg}`);
+      if (options.verbose && !options.json) {
+        console.log(chalk.yellow(`  [fail] ${task.label}: ${msg}`));
+      }
+    }
+  }
+
+  if (spinner) {
+    if (failed === 0) {
+      spinner.succeed(chalk.green(`Maintenance complete (${succeeded} tasks)`));
+    } else {
+      spinner.warn(chalk.yellow(`Maintenance done: ${succeeded} ok, ${failed} failed, ${skipped} skipped`));
+    }
+  }
+
+  if (!options.json && !suppressTable) {
+    const rows: SummaryRow[] = [
+      {
+        module: "Maintain",
+        paths: completedTasks.length,
+        freed: 0,
+        status: failed > 0 ? "error" : "freed",
+        warnings: failed + skipped,
+      },
+    ];
+    renderSummaryTable(rows);
+  }
+
+  if (errors.length > 0 && !options.json && options.verbose) {
+    for (const e of errors) {
+      console.warn(chalk.yellow(`  \u26a0 ${e}`));
+    }
+  }
+
+  const result: CleanResult = { ok: true, paths: completedTasks, freed: 0, errors };
+
+  // Audit log
+  writeAuditLog({
+    command: "clean maintain",
+    options: { dryRun: options.dryRun, json: options.json, verbose: options.verbose, noSudo: options.noSudo },
+    paths_deleted: completedTasks,
+    bytes_freed: 0,
+    errors,
+  });
+
+  return result;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,18 @@ addCleanOptions(
   process.exit(result.ok ? 0 : 1);
 });
 
+// clean maintain
+addCleanOptions(
+  cleanCmd
+    .command("maintain")
+    .description("Run macOS maintenance tasks (DNS flush, Spotlight rebuild, disk permissions, etc.)")
+).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean; secureDelete: boolean }) => {
+  const { clean } = await import("./cleaners/maintain.js");
+  const result = await clean(opts as CleanOptions);
+  outputResult(result, opts.json);
+  process.exit(result.ok ? 0 : 1);
+});
+
 // clean all
 addCleanOptions(
   cleanCmd
@@ -245,6 +257,17 @@ addCleanOptions(
     .description("Clear app usage history & recent files")
 ).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean; secureDelete: boolean }) => {
   const { clean } = await import("./cleaners/privacy.js");
+  const result = await clean(opts as CleanOptions);
+  outputResult(result, opts.json);
+  process.exit(result.ok ? 0 : 1);
+});
+
+addCleanOptions(
+  program
+    .command("maintain")
+    .description("Run macOS maintenance tasks (DNS, Spotlight, permissions, etc.)")
+).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean; secureDelete: boolean }) => {
+  const { clean } = await import("./cleaners/maintain.js");
   const result = await clean(opts as CleanOptions);
   outputResult(result, opts.json);
   process.exit(result.ok ? 0 : 1);

--- a/src/tui/scan.ts
+++ b/src/tui/scan.ts
@@ -24,6 +24,7 @@ const modules: ModuleDef[] = [
   { name: "Xcode",    key: "xcode",    importPath: "../cleaners/xcode.js" },
   { name: "Keychain", key: "keychain", importPath: "../cleaners/keychain.js" },
   { name: "Privacy",  key: "privacy",  importPath: "../cleaners/privacy.js" },
+  { name: "Maintain", key: "maintain", importPath: "../cleaners/maintain.js" },
 ];
 
 export function getModuleList(): ModuleDef[] {


### PR DESCRIPTION
## Summary
- Add `maintain` command with 7 macOS maintenance operations: DNS flush, Spotlight rebuild, disk permission repair, Launch Services database rebuild, memory purge, and font cache clear (#97)
- Integrates as both `mac-cleaner maintain` shortcut and `mac-cleaner clean maintain` subcommand, following existing CLI patterns
- Added to TUI dashboard scan/clean module list

## Implementation details
- Tasks defined as a typed array with label, command, args, requiresSudo, and description
- All commands use `spawnSync` with explicit argument arrays (no shell strings)
- 30s timeout per command to prevent hangs
- Sudo tasks (`mDNSResponder`, `mdutil`, `purge`, `atsutil`) skipped when `--no-sudo` or `--yes` is set
- `freed` is always 0 (maintenance commands don't free disk space)
- `paths` contains task labels (not file paths) for completed tasks
- Dry-run lists what would be run without executing anything
- Audit log written after execution

## Test plan
- [x] `maintain.test.ts`: dry-run returns `ok: true`
- [x] `maintain.test.ts`: CleanResult structure validates (ok, paths, freed, errors)
- [x] `maintain.test.ts`: freed is always 0
- [x] `maintain.test.ts`: paths contain task labels, not file paths
- [x] `maintain.test.ts`: sudo tasks skipped when noSudo is set
- [x] Build succeeds (`npm run build`)
- [x] CLI dry-run works: `mac-cleaner maintain --dry-run --no-sudo`
- [x] JSON output works: `mac-cleaner clean maintain --dry-run --json`
- [x] Verbose output lists all tasks with descriptions

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)