### PR TITLE
feat: cloud storage cache cleanup

### DIFF
--- a/src/cleaners/all.ts
+++ b/src/cleaners/all.ts
@@ -9,6 +9,7 @@ import * as docker from "./docker.js";
 import * as xcode from "./xcode.js";
 import * as keychain from "./keychain.js";
 import * as privacy from "./privacy.js";
+import * as cloud from "./cloud.js";
 
 interface ModuleResult {
   name: string;
@@ -31,6 +32,7 @@ export async function clean(options: CleanOptions): Promise<CleanResult> {
     { label: "xcode",    cleaner: xcode },
     { label: "keychain", cleaner: keychain as unknown as typeof system },
     { label: "privacy",  cleaner: privacy as unknown as typeof system },
+    { label: "cloud",    cleaner: cloud },
   ];
 
   const results: ModuleResult[] = [];

--- a/src/cleaners/cloud.test.ts
+++ b/src/cleaners/cloud.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import * as os from "os";
+import { clean } from "./cloud.js";
+
+describe("cloud cleaner", () => {
+  it("returns ok:true in dry-run even if no cloud services are configured", async () => {
+    const result = await clean({ dryRun: true, json: true });
+    expect(result.ok).toBe(true);
+  });
+
+  it("--json mode returns parseable CleanResult structure", async () => {
+    const result = await clean({ dryRun: true, json: true });
+
+    expect(result).toHaveProperty("ok");
+    expect(result).toHaveProperty("paths");
+    expect(result).toHaveProperty("freed");
+    expect(result).toHaveProperty("errors");
+    expect(typeof result.ok).toBe("boolean");
+    expect(Array.isArray(result.paths)).toBe(true);
+    expect(typeof result.freed).toBe("number");
+    expect(Array.isArray(result.errors)).toBe(true);
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it("paths use os.homedir() dynamically", async () => {
+    const result = await clean({ dryRun: true, json: true });
+    const home = os.homedir();
+
+    for (const p of result.paths) {
+      if (p.includes("/Users/") || p.includes("/home/")) {
+        expect(p.startsWith(home)).toBe(true);
+      }
+    }
+  });
+});

--- a/src/cleaners/cloud.ts
+++ b/src/cleaners/cloud.ts
@@ -1,0 +1,170 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import chalk from "chalk";
+import { createSpinner } from "../utils/spinner.js";
+import { CleanOptions, CleanResult } from "../types.js";
+import { duBytes, formatBytes } from "../utils/du.js";
+import { renderSummaryTable, verboseLine, truncatePath } from "../utils/format.js";
+import { writeAuditLog } from "../utils/auditLog.js";
+
+const home = os.homedir();
+
+/**
+ * Static cache directories that are safe to delete.
+ * These are macOS system caches related to cloud sync daemons.
+ */
+const CLOUD_CACHE_PATHS = [
+  path.join(home, "Library", "Caches", "CloudKit"),
+  path.join(home, "Library", "Caches", "com.apple.bird"),
+  path.join(home, "Library", "Caches", "com.apple.cloudd"),
+];
+
+/**
+ * Base directory where macOS mounts cloud storage provider folders.
+ * Provider directories match patterns like Dropbox, GoogleDrive-*, OneDrive-*.
+ */
+const CLOUD_STORAGE_BASE = path.join(home, "Library", "CloudStorage");
+
+/**
+ * Scan ~/Library/CloudStorage/ for provider folders and return their paths
+ * with sizes. These are reported for informational purposes only -- we never
+ * delete actual cloud-synced user files.
+ */
+function discoverProviderFolders(): Array<{ provider: string; dir: string }> {
+  const results: Array<{ provider: string; dir: string }> = [];
+
+  if (!fs.existsSync(CLOUD_STORAGE_BASE)) return results;
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(CLOUD_STORAGE_BASE, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+    const name = entry.name;
+
+    let provider: string | null = null;
+    if (name === "Dropbox" || name.startsWith("Dropbox-")) provider = "Dropbox";
+    else if (name.startsWith("GoogleDrive-")) provider = "Google Drive";
+    else if (name.startsWith("OneDrive-")) provider = "OneDrive";
+    else if (name.startsWith("iCloudDrive")) provider = "iCloud Drive";
+
+    if (provider) {
+      results.push({ provider, dir: path.join(CLOUD_STORAGE_BASE, name) });
+    }
+  }
+
+  return results;
+}
+
+export async function clean(options: CleanOptions): Promise<CleanResult> {
+  const spinner = options.json ? null : createSpinner("Scanning cloud storage caches...").start();
+  const errors: string[] = [];
+  const cleanedPaths: string[] = [];
+  let freed = 0;
+
+  // 1. Gather deletable cache directories
+  const cacheCandidates: Array<{ label: string; path: string }> = [];
+  for (const p of CLOUD_CACHE_PATHS) {
+    if (fs.existsSync(p)) {
+      cacheCandidates.push({ label: path.basename(p), path: p });
+    }
+  }
+
+  // 2. Discover provider folders (read-only reporting)
+  const providers = discoverProviderFolders();
+
+  if (cacheCandidates.length === 0 && providers.length === 0) {
+    if (spinner) spinner.info("No cloud storage caches found");
+    return { ok: true, paths: [], freed: 0, errors };
+  }
+
+  // Report discovered cloud storage providers (informational)
+  if (providers.length > 0 && options.verbose && !options.json) {
+    for (const { provider, dir } of providers) {
+      const size = duBytes(dir);
+      console.log(
+        chalk.gray(`    [${provider}] ${truncatePath(dir)} ${chalk.cyan(formatBytes(size))} (synced -- not deleted)`),
+      );
+    }
+  }
+
+  // ── Dry-run path ──────────────────────────────────────────────────────────
+  if (options.dryRun) {
+    if (spinner) spinner.succeed(chalk.yellow("Dry run -- nothing deleted"));
+    for (const { label, path: p } of cacheCandidates) {
+      const size = duBytes(p);
+      if (options.verbose && !options.json) {
+        verboseLine(label, p, size, true);
+      }
+      cleanedPaths.push(p);
+      freed += size;
+    }
+    if (!options.json && !(options as any)._suppressTable) {
+      renderSummaryTable([{ module: "Cloud", paths: cleanedPaths.length, freed, status: "would_free", warnings: errors.length }], true);
+    }
+    return { ok: true, paths: cleanedPaths, freed, errors };
+  }
+
+  // ── Actual clean ──────────────────────────────────────────────────────────
+  if (spinner) spinner.text = `Cleaning ${cacheCandidates.length} cloud cache paths...`;
+
+  for (const { label, path: p } of cacheCandidates) {
+    if (spinner) spinner.text = `[${label}] Cleaning: ${truncatePath(p)}`;
+    const size = duBytes(p);
+    try {
+      if (options.secureDelete && process.platform === "darwin") {
+        let stat: fs.Stats | null = null;
+        try { stat = fs.statSync(p); } catch { /* ignore */ }
+        if (stat?.isFile()) {
+          if (options.verbose && !options.json) {
+            console.log(chalk.gray(`    [secure-delete] overwriting ${p}`));
+          }
+          if (stat && stat.size > 0) {
+            try { fs.writeFileSync(p, Buffer.alloc(stat.size)); } catch { /* best-effort */ }
+          }
+        }
+      }
+      fs.rmSync(p, { recursive: true, force: true });
+      cleanedPaths.push(p);
+      freed += size;
+      if (options.verbose && !options.json) {
+        verboseLine(label, p, size, false);
+      }
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (msg.includes("EPERM") || msg.includes("EACCES")) {
+        errors.push(`Skipped (protected by macOS): ${p}`);
+      } else {
+        errors.push(`Failed to remove ${p}: ${msg}`);
+      }
+    }
+  }
+
+  if (spinner) spinner.succeed(chalk.green("Cloud storage caches cleaned"));
+
+  if (!options.json && !(options as any)._suppressTable) {
+    renderSummaryTable([{ module: "Cloud", paths: cleanedPaths.length, freed, status: "freed", warnings: errors.length }]);
+  }
+
+  if (errors.length > 0 && !options.json) {
+    for (const e of errors) {
+      console.warn(chalk.yellow(`  ⚠ ${e}`));
+    }
+  }
+
+  // Audit log
+  writeAuditLog({
+    command: "clean cloud",
+    options: { dryRun: options.dryRun, json: options.json, verbose: options.verbose, secureDelete: options.secureDelete },
+    paths_deleted: cleanedPaths,
+    bytes_freed: freed,
+    errors,
+  });
+
+  return { ok: true, paths: cleanedPaths, freed, errors };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,18 @@ addCleanOptions(
   process.exit(result.ok ? 0 : 1);
 });
 
+// clean cloud
+addCleanOptions(
+  cleanCmd
+    .command("cloud")
+    .description("Clean iCloud, Dropbox, Google Drive, and OneDrive cache directories")
+).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean; secureDelete: boolean }) => {
+  const { clean } = await import("./cleaners/cloud.js");
+  const result = await clean(opts as CleanOptions);
+  outputResult(result, opts.json);
+  process.exit(result.ok ? 0 : 1);
+});
+
 // clean all
 addCleanOptions(
   cleanCmd
@@ -245,6 +257,17 @@ addCleanOptions(
     .description("Clear app usage history & recent files")
 ).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean; secureDelete: boolean }) => {
   const { clean } = await import("./cleaners/privacy.js");
+  const result = await clean(opts as CleanOptions);
+  outputResult(result, opts.json);
+  process.exit(result.ok ? 0 : 1);
+});
+
+addCleanOptions(
+  program
+    .command("cloud")
+    .description("Clean cloud storage caches (iCloud, Dropbox, Google Drive, OneDrive)")
+).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean; secureDelete: boolean }) => {
+  const { clean } = await import("./cleaners/cloud.js");
   const result = await clean(opts as CleanOptions);
   outputResult(result, opts.json);
   process.exit(result.ok ? 0 : 1);

--- a/src/tui/scan.ts
+++ b/src/tui/scan.ts
@@ -24,6 +24,7 @@ const modules: ModuleDef[] = [
   { name: "Xcode",    key: "xcode",    importPath: "../cleaners/xcode.js" },
   { name: "Keychain", key: "keychain", importPath: "../cleaners/keychain.js" },
   { name: "Privacy",  key: "privacy",  importPath: "../cleaners/privacy.js" },
+  { name: "Cloud",    key: "cloud",    importPath: "../cleaners/cloud.js" },
 ];
 
 export function getModuleList(): ModuleDef[] {


### PR DESCRIPTION
## Summary
- Add new `cloud` cleaner module that targets macOS cloud storage cache directories (`CloudKit`, `com.apple.bird`, `com.apple.cloudd`) for safe deletion
- Scan `~/Library/CloudStorage/` for provider folders (Dropbox, Google Drive, OneDrive, iCloud Drive) and report sizes in verbose mode -- actual synced files are never deleted
- Integrate into CLI (`clean cloud` subcommand + top-level `cloud` shortcut), TUI scan module list, and `clean all` orchestrator

Closes #101

## Test plan
- [ ] `npm run build` succeeds
- [ ] `npx vitest run src/cleaners/cloud.test.ts` -- 3 tests pass (dry-run ok, CleanResult structure, homedir paths)
- [ ] `npm run dev -- cloud --dry-run` shows cache directories without deleting
- [ ] `npm run dev -- cloud --dry-run --verbose` additionally lists discovered CloudStorage provider folders
- [ ] `npm run dev -- cloud --dry-run --json` returns valid JSON with `ok`, `data.freed`, `data.paths`
- [ ] `npm run dev -- clean cloud --dry-run` works identically via subcommand syntax
- [ ] `npm run dev -- all --dry-run --json` includes `cloud` in the modules breakdown
- [ ] Graceful handling when no cloud services are configured (returns `ok: true`, empty paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)