### PR TITLE
feat: disk usage visualization (Space Lens)

### DIFF
--- a/src/commands/diskusage.test.ts
+++ b/src/commands/diskusage.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("disk-usage command", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("runDiskUsage completes without error on /tmp", async () => {
+    const { runDiskUsage } = await import("./diskusage.js");
+    // /tmp is small and fast to scan
+    await expect(runDiskUsage({ json: true, path: "/tmp" })).resolves.toBeUndefined();
+  }, 30_000);
+
+  it("JSON output has correct structure", async () => {
+    const { runDiskUsage } = await import("./diskusage.js");
+
+    const logs: string[] = [];
+    const spy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    });
+
+    await runDiskUsage({ json: true, path: "/tmp" });
+
+    expect(logs.length).toBe(1);
+    const parsed = JSON.parse(logs[0]);
+
+    expect(parsed).toHaveProperty("ok", true);
+    expect(parsed).toHaveProperty("root", "/tmp");
+    expect(parsed).toHaveProperty("totalBytes");
+    expect(typeof parsed.totalBytes).toBe("number");
+    expect(parsed).toHaveProperty("entries");
+    expect(Array.isArray(parsed.entries)).toBe(true);
+
+    // Each entry should have path, bytes, percent
+    if (parsed.entries.length > 0) {
+      const first = parsed.entries[0];
+      expect(first).toHaveProperty("path");
+      expect(first).toHaveProperty("bytes");
+      expect(first).toHaveProperty("percent");
+      expect(typeof first.bytes).toBe("number");
+      expect(typeof first.percent).toBe("number");
+    }
+
+    spy.mockRestore();
+  }, 30_000);
+
+  it("accepts a custom path argument and reflects it in output", async () => {
+    const { runDiskUsage } = await import("./diskusage.js");
+
+    const logs: string[] = [];
+    const spy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    });
+
+    await runDiskUsage({ json: true, path: "/var" });
+
+    expect(logs.length).toBe(1);
+    const parsed = JSON.parse(logs[0]);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.root).toBe("/var");
+
+    spy.mockRestore();
+  }, 30_000);
+
+  it("entries are sorted by size descending", async () => {
+    const { runDiskUsage } = await import("./diskusage.js");
+
+    const logs: string[] = [];
+    const spy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    });
+
+    await runDiskUsage({ json: true, path: "/tmp" });
+
+    const parsed = JSON.parse(logs[0]);
+    const entries = parsed.entries as { bytes: number }[];
+
+    for (let i = 1; i < entries.length; i++) {
+      expect(entries[i - 1].bytes).toBeGreaterThanOrEqual(entries[i].bytes);
+    }
+
+    spy.mockRestore();
+  }, 30_000);
+});

--- a/src/commands/diskusage.ts
+++ b/src/commands/diskusage.ts
@@ -1,0 +1,204 @@
+import { spawnSync } from "child_process";
+import { existsSync, readdirSync, statSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import chalk from "chalk";
+import ora from "ora";
+import { formatBytes } from "../utils/du.js";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface DirEntry {
+  path: string;
+  bytes: number;
+  percent: number;
+  children?: DirEntry[];
+}
+
+export interface DiskUsageResult {
+  ok: boolean;
+  root: string;
+  totalBytes: number;
+  entries: DirEntry[];
+}
+
+export interface DiskUsageOptions {
+  json: boolean;
+  path?: string;
+}
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const BAR_WIDTH = 24;
+const FILLED = "\u2588"; // █
+const EMPTY = "\u2591";  // ░
+
+/** Default top-level directories to scan under ~ */
+const DEFAULT_DIRS = [
+  "Library",
+  "Downloads",
+  "Documents",
+  "Desktop",
+  "Pictures",
+  "Music",
+  "Movies",
+  "Applications",
+  ".Trash",
+];
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Get the size of a directory in bytes using `du -sk`.
+ * Returns 0 if the path does not exist or du fails.
+ */
+function duSizeBytes(targetPath: string): number {
+  if (!existsSync(targetPath)) return 0;
+  const result = spawnSync("du", ["-sk", targetPath], {
+    encoding: "utf8",
+    timeout: 30_000,
+    // Suppress stderr (permission errors on unreadable dirs)
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  if (result.status !== 0 || !result.stdout) return 0;
+  const kb = parseInt(result.stdout.split("\t")[0], 10);
+  if (isNaN(kb)) return 0;
+  return kb * 1024;
+}
+
+/**
+ * List first-level subdirectories of a given path.
+ * Returns only directories (not files), sorted alphabetically.
+ */
+function listSubdirs(parentPath: string): string[] {
+  try {
+    return readdirSync(parentPath)
+      .map((name) => join(parentPath, name))
+      .filter((full) => {
+        try {
+          return statSync(full).isDirectory();
+        } catch {
+          return false;
+        }
+      });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Render a colored bar: green < 10%, yellow < 30%, red >= 30%.
+ */
+function renderBar(percent: number): string {
+  const filled = Math.round((percent / 100) * BAR_WIDTH);
+  const empty = BAR_WIDTH - filled;
+  const barStr = FILLED.repeat(filled) + EMPTY.repeat(empty);
+
+  if (percent < 10) return chalk.green(barStr);
+  if (percent < 30) return chalk.yellow(barStr);
+  return chalk.red(barStr);
+}
+
+/**
+ * Format a single line of the disk usage table.
+ */
+function formatLine(label: string, bytes: number, percent: number, indent: boolean): string {
+  const prefix = indent ? "  " : "";
+  const displayPath = prefix + label;
+  const sizeStr = formatBytes(bytes);
+  const pctStr = `${Math.round(percent)}%`;
+
+  // Pad columns for alignment
+  const pathCol = displayPath.padEnd(indent ? 38 : 36);
+  const sizeCol = sizeStr.padStart(10);
+  const bar = renderBar(percent);
+  const pctCol = pctStr.padStart(5);
+
+  return `${pathCol} ${sizeCol}  ${bar}  ${pctCol}`;
+}
+
+// ─── Main entry point ───────────────────────────────────────────────────────
+
+export async function runDiskUsage(opts: DiskUsageOptions): Promise<void> {
+  const root = opts.path ?? homedir();
+  const spinner = opts.json ? null : ora("Scanning disk usage...").start();
+
+  // Determine which top-level dirs to scan
+  let topDirs: string[];
+  if (opts.path) {
+    // Custom path: scan its first-level subdirectories
+    topDirs = listSubdirs(root);
+  } else {
+    // Default: scan well-known home subdirectories
+    topDirs = DEFAULT_DIRS.map((d) => join(root, d)).filter((p) => existsSync(p));
+  }
+
+  // Gather sizes for top-level directories
+  const entries: DirEntry[] = [];
+  for (const dir of topDirs) {
+    const bytes = duSizeBytes(dir);
+    if (bytes === 0) continue;
+    entries.push({ path: dir, bytes, percent: 0, children: [] });
+  }
+
+  // Sort descending by size
+  entries.sort((a, b) => b.bytes - a.bytes);
+
+  // Compute total
+  const totalBytes = entries.reduce((sum, e) => sum + e.bytes, 0);
+
+  // Set percentages
+  for (const entry of entries) {
+    entry.percent = totalBytes > 0 ? (entry.bytes / totalBytes) * 100 : 0;
+  }
+
+  // Gather one level of subdirectories for each top-level entry
+  for (const entry of entries) {
+    const subdirs = listSubdirs(entry.path);
+    const children: DirEntry[] = [];
+    for (const sub of subdirs) {
+      const bytes = duSizeBytes(sub);
+      if (bytes === 0) continue;
+      const percent = totalBytes > 0 ? (bytes / totalBytes) * 100 : 0;
+      children.push({ path: sub, bytes, percent });
+    }
+    children.sort((a, b) => b.bytes - a.bytes);
+    // Only keep the top 5 subdirectories to avoid clutter
+    entry.children = children.slice(0, 5);
+  }
+
+  if (spinner) spinner.stop();
+
+  // ─── Output ─────────────────────────────────────────────────────────────
+
+  if (opts.json) {
+    const result: DiskUsageResult = { ok: true, root, totalBytes, entries };
+    console.log(JSON.stringify(result));
+    return;
+  }
+
+  // Header
+  console.log();
+  console.log(chalk.bold("  Space Lens") + chalk.gray(` -- ${root}`));
+  console.log(chalk.gray(`  Total scanned: ${formatBytes(totalBytes)}`));
+  console.log();
+
+  // Table
+  for (const entry of entries) {
+    const label = entry.path.startsWith(homedir())
+      ? "~/" + entry.path.slice(homedir().length + 1)
+      : entry.path;
+    console.log(formatLine(label, entry.bytes, entry.percent, false));
+
+    if (entry.children) {
+      for (const child of entry.children) {
+        const childLabel = child.path.startsWith(homedir())
+          ? "~/" + child.path.slice(homedir().length + 1)
+          : child.path;
+        console.log(formatLine(childLabel, child.bytes, child.percent, true));
+      }
+    }
+  }
+
+  console.log();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -289,6 +289,18 @@ program
     await runUpgrade(opts);
   });
 
+// ─── disk-usage ─────────────────────────────────────────────────────────────
+
+program
+  .command("disk-usage")
+  .description("Show visual breakdown of disk usage by directory (Space Lens)")
+  .argument("[path]", "Directory to scan (default: home directory)")
+  .option("--json", "Output results as JSON", false)
+  .action(async (pathArg: string | undefined, opts: { json: boolean }) => {
+    const { runDiskUsage } = await import("./commands/diskusage.js");
+    await runDiskUsage({ json: opts.json, path: pathArg });
+  });
+
 // ─── TUI mode ──────────────────────────────────────────────────────────────
 
 program


### PR DESCRIPTION
## Summary
- Add `disk-usage` CLI command that shows a visual breakdown of disk usage by directory with colored Unicode bar charts, sizes, and percentages
- Scans well-known home directories by default (~\/Library, ~\/Downloads, etc.) with one level of subdirectory detail
- Supports `--json` flag for machine-parseable output and optional `[path]` argument to scan any directory
- Follows existing command pattern (registered as top-level command like `scan` / `upgrade`, uses `spawnSync` with explicit arg arrays, `formatBytes` from utils)

Closes #102

## Test plan
- [x] `npm run build` succeeds
- [x] 4 tests pass in `src/commands/diskusage.test.ts` (function runs without error, JSON structure validation, custom path argument, descending sort order)
- [ ] Manual: `npm run dev -- disk-usage` shows colored bar chart for home directory
- [ ] Manual: `npm run dev -- disk-usage /tmp` scans custom path
- [ ] Manual: `npm run dev -- disk-usage --json` outputs valid JSON with `ok`, `root`, `totalBytes`, `entries` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)