### PR TITLE
feat: mail attachments & downloads cleanup

### DIFF
--- a/src/cleaners/all.ts
+++ b/src/cleaners/all.ts
@@ -9,6 +9,7 @@ import * as docker from "./docker.js";
 import * as xcode from "./xcode.js";
 import * as keychain from "./keychain.js";
 import * as privacy from "./privacy.js";
+import * as mail from "./mail.js";
 
 interface ModuleResult {
   name: string;
@@ -31,6 +32,7 @@ export async function clean(options: CleanOptions): Promise<CleanResult> {
     { label: "xcode",    cleaner: xcode },
     { label: "keychain", cleaner: keychain as unknown as typeof system },
     { label: "privacy",  cleaner: privacy as unknown as typeof system },
+    { label: "mail",     cleaner: mail },
   ];
 
   const results: ModuleResult[] = [];

--- a/src/cleaners/mail.test.ts
+++ b/src/cleaners/mail.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import * as os from "os";
+import { clean } from "./mail.js";
+
+describe("mail cleaner", () => {
+  it("returns ok:true in dry-run even if Mail is not installed", async () => {
+    const result = await clean({ dryRun: true, json: true });
+    expect(result.ok).toBe(true);
+  });
+
+  it("--json mode returns parseable CleanResult structure", async () => {
+    const result = await clean({ dryRun: true, json: true });
+
+    expect(result).toHaveProperty("ok");
+    expect(result).toHaveProperty("paths");
+    expect(result).toHaveProperty("freed");
+    expect(result).toHaveProperty("errors");
+    expect(typeof result.ok).toBe("boolean");
+    expect(Array.isArray(result.paths)).toBe(true);
+    expect(typeof result.freed).toBe("number");
+    expect(Array.isArray(result.errors)).toBe(true);
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it("paths use os.homedir() dynamically", async () => {
+    const result = await clean({ dryRun: true, json: true });
+    const home = os.homedir();
+
+    for (const p of result.paths) {
+      if (p.includes("/Users/") || p.includes("/home/")) {
+        expect(p.startsWith(home)).toBe(true);
+      }
+    }
+  });
+});

--- a/src/cleaners/mail.ts
+++ b/src/cleaners/mail.ts
@@ -1,0 +1,118 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import chalk from "chalk";
+import { createSpinner } from "../utils/spinner.js";
+import { CleanOptions, CleanResult } from "../types.js";
+import { duBytes, formatBytes } from "../utils/du.js";
+import { renderSummaryTable, verboseLine, truncatePath } from "../utils/format.js";
+import { writeAuditLog } from "../utils/auditLog.js";
+
+const home = os.homedir();
+
+const MAIL_PATHS = [
+  path.join(home, "Library", "Containers", "com.apple.mail", "Data", "Library", "Mail Downloads"),
+  path.join(home, "Library", "Mail Downloads"),
+  path.join(home, "Library", "Containers", "com.apple.mail", "Data", "DataVaults"),
+];
+
+export async function clean(options: CleanOptions): Promise<CleanResult> {
+  const spinner = options.json ? null : createSpinner("Scanning mail attachments & downloads...").start();
+  const errors: string[] = [];
+  const cleanedPaths: string[] = [];
+  let freed = 0;
+
+  // Gather children from each existing mail path
+  const allCandidates: Array<{ label: string; path: string }> = [];
+
+  for (const dir of MAIL_PATHS) {
+    if (!fs.existsSync(dir)) continue;
+    try {
+      const entries = fs.readdirSync(dir);
+      for (const entry of entries) {
+        allCandidates.push({ label: path.basename(dir), path: path.join(dir, entry) });
+      }
+    } catch {
+      // directory unreadable — skip
+    }
+  }
+
+  if (allCandidates.length === 0) {
+    if (spinner) spinner.info("No mail attachments or downloads found");
+    return { ok: true, paths: [], freed: 0, errors };
+  }
+
+  if (options.dryRun) {
+    if (spinner) spinner.succeed(chalk.yellow("Dry run -- nothing deleted"));
+    for (const { label, path: p } of allCandidates) {
+      const size = duBytes(p);
+      if (options.verbose && !options.json) {
+        verboseLine(label, p, size, true);
+      }
+      cleanedPaths.push(p);
+      freed += size;
+    }
+    if (!options.json && !(options as any)._suppressTable) {
+      renderSummaryTable([{ module: "Mail", paths: cleanedPaths.length, freed, status: "would_free", warnings: errors.length }], true);
+    }
+    return { ok: true, paths: cleanedPaths, freed, errors };
+  }
+
+  if (spinner) spinner.text = `Cleaning ${allCandidates.length} mail cache paths...`;
+
+  for (const { label, path: p } of allCandidates) {
+    if (spinner) spinner.text = `[${label}] Cleaning: ${truncatePath(p)}`;
+    const size = duBytes(p);
+    try {
+      // #41: Secure delete — overwrite file with zeros before removal (macOS, files only)
+      if (options.secureDelete && process.platform === "darwin") {
+        let stat: fs.Stats | null = null;
+        try { stat = fs.statSync(p); } catch { /* ignore */ }
+        if (stat?.isFile()) {
+          if (options.verbose && !options.json) {
+            console.log(chalk.gray(`    [secure-delete] overwriting ${p}`));
+          }
+          if (stat && stat.size > 0) {
+            try { fs.writeFileSync(p, Buffer.alloc(stat.size)); } catch { /* best-effort */ }
+          }
+        }
+      }
+      fs.rmSync(p, { recursive: true, force: true });
+      cleanedPaths.push(p);
+      freed += size;
+      if (options.verbose && !options.json) {
+        verboseLine(label, p, size, false);
+      }
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (msg.includes("EPERM") || msg.includes("EACCES")) {
+        errors.push(`Skipped (protected by macOS): ${p}`);
+      } else {
+        errors.push(`Failed to remove ${p}: ${msg}`);
+      }
+    }
+  }
+
+  if (spinner) spinner.succeed(chalk.green("Mail attachments & downloads cleaned"));
+
+  if (!options.json && !(options as any)._suppressTable) {
+    renderSummaryTable([{ module: "Mail", paths: cleanedPaths.length, freed, status: "freed", warnings: errors.length }]);
+  }
+
+  if (errors.length > 0 && !options.json) {
+    for (const e of errors) {
+      console.warn(chalk.yellow(`  ⚠ ${e}`));
+    }
+  }
+
+  // #44: Audit log
+  writeAuditLog({
+    command: "clean mail",
+    options: { dryRun: options.dryRun, json: options.json, verbose: options.verbose, secureDelete: options.secureDelete },
+    paths_deleted: cleanedPaths,
+    bytes_freed: freed,
+    errors,
+  });
+
+  return { ok: true, paths: cleanedPaths, freed, errors };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,18 @@ addCleanOptions(
   process.exit(result.ok ? 0 : 1);
 });
 
+// clean mail
+addCleanOptions(
+  cleanCmd
+    .command("mail")
+    .description("Clean cached mail attachments and downloads from Apple Mail")
+).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean; secureDelete: boolean }) => {
+  const { clean } = await import("./cleaners/mail.js");
+  const result = await clean(opts as CleanOptions);
+  outputResult(result, opts.json);
+  process.exit(result.ok ? 0 : 1);
+});
+
 // clean all
 addCleanOptions(
   cleanCmd
@@ -245,6 +257,17 @@ addCleanOptions(
     .description("Clear app usage history & recent files")
 ).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean; secureDelete: boolean }) => {
   const { clean } = await import("./cleaners/privacy.js");
+  const result = await clean(opts as CleanOptions);
+  outputResult(result, opts.json);
+  process.exit(result.ok ? 0 : 1);
+});
+
+addCleanOptions(
+  program
+    .command("mail")
+    .description("Clean cached mail attachments & downloads")
+).action(async (opts: { dryRun: boolean; json: boolean; verbose: boolean; noSudo: boolean; yes: boolean; secureDelete: boolean }) => {
+  const { clean } = await import("./cleaners/mail.js");
   const result = await clean(opts as CleanOptions);
   outputResult(result, opts.json);
   process.exit(result.ok ? 0 : 1);

--- a/src/tui/scan.ts
+++ b/src/tui/scan.ts
@@ -24,6 +24,7 @@ const modules: ModuleDef[] = [
   { name: "Xcode",    key: "xcode",    importPath: "../cleaners/xcode.js" },
   { name: "Keychain", key: "keychain", importPath: "../cleaners/keychain.js" },
   { name: "Privacy",  key: "privacy",  importPath: "../cleaners/privacy.js" },
+  { name: "Mail",     key: "mail",     importPath: "../cleaners/mail.js" },
 ];
 
 export function getModuleList(): ModuleDef[] {


### PR DESCRIPTION
## Summary

- Add new `mail` cleaner module that removes cached attachments and downloads from Apple Mail (`~/Library/Containers/com.apple.mail/Data/Library/Mail Downloads/`, `~/Library/Mail Downloads/`, `~/Library/Containers/com.apple.mail/Data/DataVaults/`)
- Deletes children of target directories (not the dirs themselves); safe since Mail re-downloads attachments on demand
- Integrated into CLI (`mac-cleaner mail` / `mac-cleaner clean mail`), `clean all` orchestrator, and TUI scan module

Closes #100

## Test plan

- [x] `npm run build` succeeds
- [x] `npx vitest run src/cleaners/mail.test.ts` -- all 3 tests pass (dry-run ok, CleanResult structure, homedir paths)
- [x] Full test suite passes (pre-existing node timeout unrelated)
- [ ] `mac-cleaner mail --dry-run` shows found paths or "No mail attachments" gracefully
- [ ] `mac-cleaner clean mail --dry-run --json` returns valid JSON CleanResult
- [ ] `mac-cleaner clean all --dry-run` includes mail in aggregated output
- [ ] TUI `menu` scan includes Mail module in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)